### PR TITLE
Fix and feat related to the backoff smoothing references in the Optional Work

### DIFF
--- a/HMM Tagger.ipynb
+++ b/HMM Tagger.ipynb
@@ -819,7 +819,7 @@
     "    Laplace smoothing is a technique where you add a small, non-zero value to all observed counts to offset for unobserved values.\n",
     "\n",
     "- Backoff Smoothing\n",
-    "    Another smoothing technique is to interpolate between n-grams for missing data. This method is more effective than Laplace smoothing at combatting the data sparsity problem. Refer to chapters 4, 9, and 10 of the [Speech & Language Processing](https://web.stanford.edu/~jurafsky/slp3/) book for more information.\n",
+    "    Another smoothing technique is to interpolate between n-grams for missing data. This method is more effective than Laplace smoothing at combatting the data sparsity problem. Refer to chapters 3 and 26 of the [Speech & Language Processing](https://web.stanford.edu/~jurafsky/slp3/) book for more information.\n",
     "\n",
     "- Extending to Trigrams\n",
     "    HMM taggers have achieved better than 96% accuracy on this dataset with the full Penn treebank tagset using an architecture described in [this](http://www.coli.uni-saarland.de/~thorsten/publications/Brants-ANLP00.pdf) paper. Altering your HMM to achieve the same performance would require implementing deleted interpolation (described in the paper), incorporating trigram probabilities in your frequency tables, and re-implementing the Viterbi algorithm to consider three consecutive states instead of two.\n",

--- a/HMM Tagger.ipynb
+++ b/HMM Tagger.ipynb
@@ -819,7 +819,7 @@
     "    Laplace smoothing is a technique where you add a small, non-zero value to all observed counts to offset for unobserved values.\n",
     "\n",
     "- Backoff Smoothing\n",
-    "    Another smoothing technique is to interpolate between n-grams for missing data. This method is more effective than Laplace smoothing at combatting the data sparsity problem. Refer to chapters 3 and 26 of the [Speech & Language Processing](https://web.stanford.edu/~jurafsky/slp3/) book for more information.\n",
+    "    Another smoothing technique is to interpolate between n-grams for missing data. This method is more effective than Laplace smoothing at combatting the data sparsity problem. Refer to chapters 3 and 26 of the [Speech & Language Processing](https://web.stanford.edu/~jurafsky/slp3/) book, or to this [video lecture](https://youtu.be/oZHRFj8heWM) by the same author, for more information.\n",
     "\n",
     "- Extending to Trigrams\n",
     "    HMM taggers have achieved better than 96% accuracy on this dataset with the full Penn treebank tagset using an architecture described in [this](http://www.coli.uni-saarland.de/~thorsten/publications/Brants-ANLP00.pdf) paper. Altering your HMM to achieve the same performance would require implementing deleted interpolation (described in the paper), incorporating trigram probabilities in your frequency tables, and re-implementing the Viterbi algorithm to consider three consecutive states instead of two.\n",


### PR DESCRIPTION
I do suggest one fix and one feat to the back off smoothing references in Step4. 

### Fix
**Updating the chapter references in step 4**

The Chapters references mentioned (4,9,10) refer to the [second edition ](https://home.cs.colorado.edu/~martin/slp.html)of the Speech and Language Processing textbook, while **[the provided link](https://web.stanford.edu/~jurafsky/slp3/)**, refers to the current edition, the 3rd edition, which have been restructured.

In the third edition, as of December 30, 2020 draft release, the following changes have been amended by the authors:

- Chapter 4 of the 2nd ed. is now [Chapter 3](https://web.stanford.edu/~jurafsky/slp3/3.pdf) of the 3rd ed. 
- Chapter 9 of the 2nd ed. is now [Chapter 26](https://web.stanford.edu/~jurafsky/slp3/26.pdf) of the 3rd ed. 
- Chapter 10 of the 2nd ed. content have been discarded.

### Feature
**Backoff smoothing Stanford video lecture**

There is a video lecture by Dan Jurafsky and Chris Manning, about Backoff smoothing and Interpolation, published in their [Natural Language Processing 2012 lectures playlist](https://www.youtube.com/playlist?list=PLoROMvodv4rOFZnDyrlW3-nI7tMLtmiJZ) on Youtube; referenced in their [personal pages](https://web.stanford.edu/~jurafsky/).

Dan Jurafsky is a co-author of the mentioned book, Speech and Language Processing.

[Lecture: NLP 2012 Dan Jurafsky and Chris Manning (3.6) Interpolation](https://www.youtube.com/watch?v=oZHRFj8heWM&list=PLoROMvodv4rOFZnDyrlW3-nI7tMLtmiJZ&index=17) 


